### PR TITLE
Chore/merge componentsjs patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.10",
       "license": "MIT",
       "dependencies": {
-        "componentsjs": "5.0.0-beta.3",
+        "componentsjs": "5.0.0-beta.4",
         "express": "^4.17.2",
         "node-mocks-http": "^1.11.0",
         "prom-client": "^14.0.1",
@@ -3158,9 +3158,9 @@
       }
     },
     "node_modules/componentsjs": {
-      "version": "5.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-5.0.0-beta.3.tgz",
-      "integrity": "sha512-qAhUa4vJ4FsVCQGSg29OOeG00IP80uNzlyHd5eo03lA5qJZJrewzDQ9m6feAx1ljoj3oOr4nEsfxBtZ2ax/G7w==",
+      "version": "5.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-5.0.0-beta.4.tgz",
+      "integrity": "sha512-BB/xdmPC0ICKZTGV6WLQjAezk0khTSyblE4Sq4ugNINoVGi/C3uGm8o4EmRhvekZL/MyExlVyMcjvACtBlV2RQ==",
       "dependencies": {
         "@rdfjs/types": "*",
         "@types/minimist": "^1.2.0",
@@ -13153,9 +13153,9 @@
       }
     },
     "componentsjs": {
-      "version": "5.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-5.0.0-beta.3.tgz",
-      "integrity": "sha512-qAhUa4vJ4FsVCQGSg29OOeG00IP80uNzlyHd5eo03lA5qJZJrewzDQ9m6feAx1ljoj3oOr4nEsfxBtZ2ax/G7w==",
+      "version": "5.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-5.0.0-beta.4.tgz",
+      "integrity": "sha512-BB/xdmPC0ICKZTGV6WLQjAezk0khTSyblE4Sq4ugNINoVGi/C3uGm8o4EmRhvekZL/MyExlVyMcjvACtBlV2RQ==",
       "requires": {
         "@rdfjs/types": "*",
         "@types/minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript": "4.5.5"
   },
   "dependencies": {
-    "componentsjs": "5.0.0-beta.3",
+    "componentsjs": "5.0.0-beta.4",
     "express": "^4.17.2",
     "node-mocks-http": "^1.11.0",
     "prom-client": "^14.0.1",


### PR DESCRIPTION
Upgrading `componentsjs (v5.0.0-beta.3 -> v5.0.0-beta.4)` and `componentsjs-generator (v3.0.0-beta.5 -> v3.0.0-beta.6)` packages must be upgraded at the same time to succeed.

This PR iIncorporates the following changes::

* https://github.com/iotakingdoms/auth/pull/37
* https://github.com/iotakingdoms/auth/pull/36

Upgrading the packages individually cause the following error at runtime:

```
/home/runner/work/auth/auth/node_modules/componentsjs/lib/rdf/RdfParser.js:85
        return new Error(`Error while parsing file "${path}": ${error.message}`);
               ^

Error: Error while parsing file "/REDACTED/dist/app/App.jsonld": Invalid predicate IRI: memberKeys
```